### PR TITLE
remove encryption

### DIFF
--- a/Support_Your_Locals/Startup.cs
+++ b/Support_Your_Locals/Startup.cs
@@ -35,7 +35,6 @@ namespace Support_Your_Locals
                 InitialCatalog = Configuration["Database:Name"],
                 UserID = Configuration["Database:Username"],
                 Password = Configuration["Database:Password"],
-                Encrypt = true,
                 MultipleActiveResultSets = true,
                 TrustServerCertificate = true,
             };


### PR DESCRIPTION
Removing encryption from the database because LocalDB does not support it. At the moment we don't need it on azure too because we are not using user sensitive data later we can add this flag. 